### PR TITLE
Translate comments to Vietnamese

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,24 @@
-# HTTP
+# HTTP - cấu hình cổng và máy chủ cho dịch vụ
 PORT=8080
 HOST=0.0.0.0
 NODE_ENV=production
 
-# DB
+# CƠ SỞ DỮ LIỆU - chuỗi kết nối PostgreSQL
 DATABASE_URL=postgresql://asi:asi@db:5432/asi?schema=public
 
-# REDIS
+# REDIS - cấu hình máy chủ Redis dùng cho cache và hàng đợi
 REDIS_URL=redis://redis:6379
 
-# CMS
+# CMS - webhook và khóa HMAC cho hệ thống CMS
 CMS_ENDPOINT=https://cms.example.com/attendance/webhook
 CMS_HMAC_KEY=change_me
 
-# INBOUND (thiết bị -> gateway)
+# LUỒNG VÀO (thiết bị -> gateway) - thông tin xác thực và danh sách IP được phép
 INBOUND_BASIC_USER=asi
 INBOUND_BASIC_PASS=strong_password
 ALLOWLIST_CIDRS=10.0.0.0/8,192.168.0.0/16
 
-# DEVICE TLS (optional mTLS)
+# TLS CHO THIẾT BỊ (mTLS tùy chọn) - bật TLS và chỉ định đường dẫn chứng chỉ
 TLS_ENABLE=false
 TLS_KEY_PATH=/certs/server.key
 TLS_CERT_PATH=/certs/server.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-# Stage 1: build
+# Giai đoạn 1: xây dựng mã nguồn và biên dịch TypeScript
 FROM node:20-alpine AS build
 WORKDIR /app
 COPY package*.json tsconfig.json .
 COPY src src
 RUN npm install && npm run build
 
-# Stage 2: run
+# Giai đoạn 2: chạy ứng dụng Node.js đã biên dịch
 FROM node:20-alpine AS run
 WORKDIR /app
 COPY --from=build /app/dist dist


### PR DESCRIPTION
## Summary
- Localize Dockerfile stages to Vietnamese with clearer descriptions
- Document environment variables in Vietnamese within `.env.example`

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c2964d09b883338a3bb9423e4ff0bd