### PR TITLE
feat: add Dahua device management

### DIFF
--- a/src/core/prisma.ts
+++ b/src/core/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();

--- a/src/devices/device-service.ts
+++ b/src/devices/device-service.ts
@@ -1,0 +1,69 @@
+import fetch from 'node-fetch';
+import { prisma } from '../core/prisma.js';
+import { logger } from '../core/logger.js';
+
+export interface DeviceInput {
+  name: string;
+  ip: string;
+  port?: number;
+  username: string;
+  password: string;
+  https?: boolean;
+}
+
+export async function registerDevice(data: DeviceInput) {
+  return prisma.device.create({ data });
+}
+
+export async function listDevices() {
+  return prisma.device.findMany();
+}
+
+export async function getDevice(id: string) {
+  return prisma.device.findUnique({ where: { id } });
+}
+
+export async function updateDevice(id: string, data: Partial<DeviceInput>) {
+  return prisma.device.update({ where: { id }, data });
+}
+
+export async function removeDevice(id: string) {
+  return prisma.device.delete({ where: { id } });
+}
+
+export async function pingDevice(device: {
+  ip: string;
+  port: number;
+  username: string;
+  password: string;
+  https: boolean;
+}) {
+  const scheme = device.https ? 'https' : 'http';
+  const url = `${scheme}://${device.ip}:${device.port}/cgi-bin/magicBox.cgi?action=getDeviceType`;
+  try {
+    const res = await fetch(url, {
+      timeout: 3000,
+      headers: {
+        Authorization:
+          'Basic ' + Buffer.from(`${device.username}:${device.password}`).toString('base64'),
+      },
+    });
+    return res.ok;
+  } catch (err) {
+    logger.warn({ err }, 'pingDevice failed');
+    return false;
+  }
+}
+
+export async function refreshStatus(id: string) {
+  const device = await getDevice(id);
+  if (!device) return null;
+  const ok = await pingDevice(device);
+  return prisma.device.update({
+    where: { id },
+    data: {
+      status: ok ? 'online' : 'offline',
+      lastSeenAt: ok ? new Date() : device.lastSeenAt,
+    },
+  });
+}

--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -1,0 +1,1 @@
+export * from './device-service.js';

--- a/tests/device-ping.spec.ts
+++ b/tests/device-ping.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { pingDevice } from '../src/devices/device-service.js';
+
+vi.mock('node-fetch', () => ({
+  default: vi.fn(() => Promise.resolve({ ok: true }))
+}));
+
+describe('pingDevice', () => {
+  const device = {
+    ip: '1.2.3.4',
+    port: 80,
+    username: 'admin',
+    password: 'pass',
+    https: false,
+  };
+
+  it('returns true when device responds', async () => {
+    const result = await pingDevice(device);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when fetch fails', async () => {
+    const fetch = (await import('node-fetch')).default as any;
+    fetch.mockImplementationOnce(() => Promise.reject(new Error('fail')));
+    const result = await pingDevice(device);
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add Prisma client helper
- implement Dahua device CRUD and health check
- cover device ping logic with tests

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c29bfff6208333bd54444ab659949f