### PR TITLE
Handle HRM response variations

### DIFF
--- a/src/cms/hrm-client.ts
+++ b/src/cms/hrm-client.ts
@@ -13,5 +13,6 @@ export async function fetchEmployees() {
   if (!res.ok) {
     throw new Error(`HRM fetch error: ${res.status} ${await res.text()}`);
   }
-  return res.json();
+  const resJson = await res.json();
+  return resJson?.data ?? resJson;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,11 @@ async function buildServer() {
   app.get('/readyz', async () => ({ status: 'ready' }));
 
   app.post('/cms/sync-employees', async (req, reply) => {
-    const employees = await fetchEmployees();
+    const raw = await fetchEmployees();
+    const employees = Array.isArray(raw) ? raw : [raw];
+    if (!Array.isArray(raw)) {
+      logger.warn({ raw }, 'fetchEmployees returned non-array data');
+    }
     const users = await Promise.all(
       employees.map(async (e: any) => {
         let faceImageBase64 = e.FaceImageBase64;


### PR DESCRIPTION
## Summary
- Parse HRM responses to extract `data` when present.
- Normalize HRM employee data to an array in the sync endpoint and log when non-array payloads are received.

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c39f47f23483338fee2fa13f3e750a