### PR TITLE
Handle Prisma connection errors in sync endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,12 @@ async function buildServer() {
         };
       })
     );
-    await syncUsersToAsi(users);
+    try {
+      await syncUsersToAsi(users);
+    } catch (err) {
+      logger.error({ err }, 'syncUsersToAsi failed');
+      return reply.status(503).send({ status: 'error', message: 'service unavailable' });
+    }
     reply.send({ status: 'ok', count: users.length });
   });
   return app;

--- a/src/users/sync-service.ts
+++ b/src/users/sync-service.ts
@@ -19,7 +19,13 @@ function chunk<T>(arr: T[], size: number): T[][] {
 
 export async function syncUsersToAsi(users: UserSyncItem[]): Promise<void> {
   logger.info({ count: users.length }, 'syncUsersToAsi triggered');
-  const devices = await listDevices();
+  let devices;
+  try {
+    devices = await listDevices();
+  } catch (err) {
+    logger.error({ err }, 'listDevices failed');
+    throw err;
+  }
   for (const device of devices) {
     await syncToDevice(device, users);
   }

--- a/tests/sync-fallback.spec.ts
+++ b/tests/sync-fallback.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../src/cms/hrm-client.js', () => ({
+  fetchEmployees: vi.fn(() => Promise.resolve([{ EmployeeID: 1, FullName: 'A' }]))
+}));
+
+vi.mock('../src/devices/index.js', () => ({
+  listDevices: vi.fn(() => Promise.reject(new Error('db down')))
+}));
+
+import { buildServer } from '../src/index.js';
+
+describe('POST /cms/sync-employees fallback', () => {
+  it('returns 503 when device listing fails', async () => {
+    const app = await buildServer();
+    const res = await app.inject({ method: 'POST', url: '/cms/sync-employees' });
+    expect(res.statusCode).toBe(503);
+  });
+});


### PR DESCRIPTION
## Summary
- wrap device lookup in try/catch to surface connection errors
- return HTTP 503 from /cms/sync-employees when sync fails
- test sync endpoint for graceful fallback when Prisma connection fails

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*


------
https://chatgpt.com/codex/tasks/task_e_68c3a393ef088333ac8de6bfaa959831