### PR TITLE
feat: add http fetch utility

### DIFF
--- a/src/core/http-fetch.ts
+++ b/src/core/http-fetch.ts
@@ -1,0 +1,27 @@
+import fetch from 'node-fetch';
+
+/**
+ * Fetch a resource as a Buffer with simple retry logic.
+ *
+ * @param url The URL to fetch.
+ * @param retries Number of attempts before failing.
+ */
+export async function fetchBufferWithRetry(
+  url: string,
+  retries = 0,
+): Promise<Buffer> {
+  let lastErr: any;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const arr = await res.arrayBuffer();
+      return Buffer.from(arr);
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr;
+}


### PR DESCRIPTION
## Summary
- add retryable HTTP buffer fetch helper

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d8f05fb48333bb09054dc916d800