### PR TITLE
feat: retry CMS forwarding for alarms

### DIFF
--- a/src/alarms/tcp-listener.ts
+++ b/src/alarms/tcp-listener.ts
@@ -5,6 +5,11 @@ import fetch from "node-fetch";
 const PORT = parseInt(process.env.ALARM_TCP_PORT || "8888", 10);
 const CMS_ENDPOINT = process.env.CMS_ENDPOINT!;
 const CMS_HMAC_KEY = process.env.CMS_HMAC_KEY || "change_me";
+const MAX_RETRIES = parseInt(process.env.ALARM_MAX_RETRIES || "3", 10);
+const RETRY_BACKOFF_MS = parseInt(
+  process.env.ALARM_RETRY_BACKOFF_MS || "1000",
+  10
+);
 
 // (tùy chọn) xác thực thiết bị theo User/Pass đã cấu hình ở AlarmServer.UserName/Password
 const INBOUND_USER = process.env.INBOUND_BASIC_USER || "admin";
@@ -68,6 +73,36 @@ async function forwardToCMS(evt: any) {
   }
 }
 
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export const failedEvents: any[] = [];
+
+export async function forwardWithRetry(evt: any, logger = console) {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      await forwardToCMS(evt);
+      return;
+    } catch (err: any) {
+      logger.warn?.(
+        { err: err.message, attempt: attempt + 1 },
+        "cms-forward-retry"
+      );
+      const delay = RETRY_BACKOFF_MS * Math.pow(2, attempt);
+      await wait(delay);
+    }
+  }
+  failedEvents.push(evt);
+}
+
+export async function processFailedEvents(logger = console) {
+  while (failedEvents.length) {
+    const evt = failedEvents.shift();
+    if (evt) await forwardWithRetry(evt, logger);
+  }
+}
+
 export function startAlarmTcpServer(logger = console) {
   const server = net.createServer((socket) => {
     const peer = `${socket.remoteAddress}:${socket.remotePort}`;
@@ -95,7 +130,7 @@ export function startAlarmTcpServer(logger = console) {
 
         const evt = tryParseEvent(chunk);
         logger.info?.({ peer, evt }, "alarm-event");
-        await forwardToCMS(evt);
+        await forwardWithRetry(evt, logger);
         socket.write("ACK\n");
       } catch (e: any) {
         logger.error?.({ peer, err: e.message }, "alarm-forward-error");
@@ -111,6 +146,8 @@ export function startAlarmTcpServer(logger = console) {
   server.listen(PORT, "0.0.0.0", () => {
     logger.info?.(`Alarm TCP listening on 0.0.0.0:${PORT}`);
   });
+
+  setInterval(() => processFailedEvents(logger), RETRY_BACKOFF_MS).unref();
 
   return server;
 }

--- a/tests/alarm-retry.spec.ts
+++ b/tests/alarm-retry.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.useFakeTimers();
+
+vi.mock('node-fetch', () => ({
+  default: vi.fn(),
+}));
+
+describe('forwardWithRetry', () => {
+  it('retries and queues events on CMS failure', async () => {
+    process.env.ALARM_MAX_RETRIES = '2';
+    process.env.ALARM_RETRY_BACKOFF_MS = '10';
+    const mod = await import('../src/alarms/tcp-listener.js');
+    const fetchMod = await import('node-fetch');
+    const fetchMock = fetchMod.default as unknown as vi.Mock;
+
+    fetchMock.mockRejectedValue(new Error('fail'));
+    const evt = { foo: 'bar' };
+    const p = mod.forwardWithRetry(evt);
+    await vi.runAllTimersAsync();
+    await p;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(mod.failedEvents.length).toBe(1);
+
+    fetchMock.mockResolvedValue({ ok: true, text: async () => '' } as any);
+    const p2 = mod.processFailedEvents();
+    await vi.runAllTimersAsync();
+    await p2;
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(mod.failedEvents.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add configurable retry and backoff when forwarding alarms to CMS
- queue failed events and retry later
- test retry queue handling on CMS failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6769deab88333b46fc1715cc96b8d