### PR TITLE
Validate required CMS env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ npm run dev
 
 API documentation available via OpenAPI at `/docs` when the server is running.
 
+## Environment Variables
+
+The gateway requires several environment variables to be defined at startup:
+
+- `CMS_ENDPOINT` – URL where alarm events are forwarded.
+- `CMS_HMAC_KEY` – shared secret used to sign webhook payloads.
+- `CMS_HRM_ENDPOINT` – CMS API endpoint for fetching employee data.
+- `CMS_HRM_AUTH_HEADER` – authorization header for the HRM API.
+
+Values can be supplied via the shell environment or a `.env` file. The
+application will throw an error during initialization if any of the required
+variables are missing.
+
 ### User Sync Example
 
 ```json

--- a/src/alarms/tcp-listener.ts
+++ b/src/alarms/tcp-listener.ts
@@ -1,10 +1,10 @@
 import net from "net";
 import crypto from "crypto";
 import fetch from "node-fetch";
+import { env } from "../core/env";
 
 const PORT = parseInt(process.env.ALARM_TCP_PORT || "8888", 10);
-const CMS_ENDPOINT = process.env.CMS_ENDPOINT!;
-const CMS_HMAC_KEY = process.env.CMS_HMAC_KEY || "change_me";
+const { cmsEndpoint: CMS_ENDPOINT, cmsHmacKey: CMS_HMAC_KEY } = env;
 
 // (tùy chọn) xác thực thiết bị theo User/Pass đã cấu hình ở AlarmServer.UserName/Password
 const INBOUND_USER = process.env.INBOUND_BASIC_USER || "admin";

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -1,11 +1,19 @@
 import { config } from 'dotenv';
 config();
 
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
 export const env = {
   port: parseInt(process.env.PORT || '8080', 10),
   host: process.env.HOST || '0.0.0.0',
-  cmsEndpoint: process.env.CMS_ENDPOINT || '',
-  cmsHmacKey: process.env.CMS_HMAC_KEY || '',
-  cmsHrmEndpoint: process.env.CMS_HRM_ENDPOINT || '',
-  cmsHrmAuthHeader: process.env.CMS_HRM_AUTH_HEADER || '',
+  cmsEndpoint: requireEnv('CMS_ENDPOINT'),
+  cmsHmacKey: requireEnv('CMS_HMAC_KEY'),
+  cmsHrmEndpoint: requireEnv('CMS_HRM_ENDPOINT'),
+  cmsHrmAuthHeader: requireEnv('CMS_HRM_AUTH_HEADER'),
 };


### PR DESCRIPTION
## Summary
- validate critical CMS-related environment variables at startup
- update alarm TCP listener to read validated env values
- document required environment variables in README

## Testing
- `CMS_ENDPOINT=http://example.com CMS_HMAC_KEY=secret CMS_HRM_ENDPOINT=http://hrm.example.com CMS_HRM_AUTH_HEADER=token npm test -- --run`
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_68c6769b9ed88333b842392d749ea8c0