### PR TITLE
docs: add docker compose instructions and usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ npm run dev
 
 API documentation available via OpenAPI at `/docs` when the server is running.
 
+## Build and Run (Docker Compose)
+
+```bash
+docker compose build --no-cache app
+docker compose up -d
+docker compose logs -f app
+```
+
 ## Environment Variables
 
 The gateway requires several environment variables to be defined at startup:

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,27 @@
+# Hướng dẫn sử dụng
+
+## Kết nối ASI
+
+- Đăng ký thiết bị qua API `POST /devices` với địa chỉ IP, cổng và thông tin đăng nhập.
+- Có thể kiểm tra lại danh sách thiết bị bằng `GET /devices`.
+
+## Tích hợp CMS
+
+- Cấu hình các biến môi trường `CMS_ENDPOINT`, `CMS_HMAC_KEY`, `CMS_HRM_ENDPOINT`, `CMS_HRM_AUTH_HEADER`.
+- Sau khi khởi động gateway, gọi `POST /cms/sync-employees` để đồng bộ nhân viên từ CMS sang các thiết bị ASI.
+
+## Câu lệnh sử dụng
+
+- Chạy ở chế độ phát triển: `npm run dev`
+- Build dự án: `npm run build`
+- Khởi động từ bản build: `npm start`
+- Đồng bộ nhân viên: `curl -X POST http://<host>:<port>/cms/sync-employees`
+
+## API và cách dùng
+
+- Tài liệu OpenAPI có tại đường dẫn `/docs` khi dịch vụ chạy.
+- Các API chính:
+  - `POST /devices` đăng ký thiết bị ASI.
+  - `GET /devices` liệt kê thiết bị.
+  - `POST /cms/sync-employees` đồng bộ nhân viên từ CMS.
+  - Webhook sự kiện từ thiết bị: `POST /asi/webhook`.


### PR DESCRIPTION
## Summary
- document docker compose build and run steps
- add Vietnamese usage guide for ASI connection, CMS integration, CLI commands, and API usage

## Testing
- `npm test` *(fails: expected +0 to be 1)*
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_68c69ce5d99083339cbca263442e4430