### PR TITLE
Validate addFace input

### DIFF
--- a/src/users/sync-service.ts
+++ b/src/users/sync-service.ts
@@ -141,6 +141,19 @@ export async function addFace(
     "Content-Type": "application/json",
   } as const;
 
+  if (typeof userId !== "string" || userId.trim() === "") {
+    logger.warn({ deviceId: device.id, userId }, "addFace skipped: invalid userId");
+    return;
+  }
+  const base64Regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+  if (typeof photoBase64 !== "string" || !base64Regex.test(photoBase64)) {
+    logger.warn(
+      { deviceId: device.id, userId },
+      "addFace skipped: invalid photoBase64",
+    );
+    return;
+  }
+
   const info: Record<string, unknown> = { PhotoData: [photoBase64] };
   if (userName) info.UserName = userName;
 

--- a/tests/sync-service.spec.ts
+++ b/tests/sync-service.spec.ts
@@ -23,7 +23,7 @@ describe('syncUsersToAsi', () => {
     fetch.mockImplementation(
       () => new Promise((res) => setTimeout(() => res({ ok: true }), 50)),
     );
-    const users = [{ userId: '1', name: 'A', faceImageBase64: 'x' }];
+    const users = [{ userId: '1', name: 'A', faceImageBase64: 'eA==' }];
     const start = Date.now();
     await syncUsersToAsi(users);
     const duration = Date.now() - start;
@@ -47,7 +47,7 @@ describe('syncToDevice', () => {
     const users = Array.from({ length: 4 }, (_, i) => ({
       userId: String(i),
       name: `U${i}`,
-      faceImageBase64: 'x',
+      faceImageBase64: 'eA==',
     }));
     const start = Date.now();
     await syncToDevice(device, users, 2);


### PR DESCRIPTION
## Summary
- validate `addFace` parameters before network request
- update sync service tests with valid base64 values

## Testing
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7c7a821408333903f06362135cd3a