### PR TITLE
fix: use default keep-alive timeout

### DIFF
--- a/src/utils/digest.ts
+++ b/src/utils/digest.ts
@@ -2,8 +2,6 @@ import crypto from "node:crypto";
 import { request, Agent } from "undici";
 
 const agent = new Agent({
-  keepAliveTimeout: 0,
-  keepAliveMaxTimeout: 0,
   connect: { timeout: 10_000 },
 });
 


### PR DESCRIPTION
## Summary
- remove the invalid keep-alive overrides from the digest helper's Undici agent so the configuration is accepted while still using `Connection: close`

## Testing
- npm test *(fails: tests/sync-service.spec.ts > syncToDevice > batches and sends face requests with a concurrency limit — expected "spy" to be called 4 times, but got 0 times)*

------
https://chatgpt.com/codex/tasks/task_e_68cd37566a5483339b51145357062d4b