### PR TITLE
fix: set keep-alive timeouts for digest agent

### DIFF
--- a/src/utils/digest.ts
+++ b/src/utils/digest.ts
@@ -3,6 +3,8 @@ import { request, Agent } from "undici";
 
 const agent = new Agent({
   connect: { timeout: 10_000 },
+  keepAliveTimeout: 10_000,
+  keepAliveMaxTimeout: 30_000,
 });
 
 function parseWwwAuth(h: string) {


### PR DESCRIPTION
## Summary
- configure the shared undici agent used by digest helpers with explicit keep-alive timeouts to avoid zero-valued defaults

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0c79b62ac8333bbd955e88a878820