### PR TITLE
Remove expect header from digest requests

### DIFF
--- a/src/utils/digest.ts
+++ b/src/utils/digest.ts
@@ -80,7 +80,6 @@ export async function digestPostJson(
     headers: {
       "content-length": "0",
       connection: "close",
-      expect: "",
     },
     body: Buffer.alloc(0),
   });
@@ -111,7 +110,6 @@ export async function digestPostJson(
         "content-type": "application/json; charset=UTF-8",
         "content-length": String(buf.length),
         connection: "close",
-        expect: "",
       },
       body: buf,
     });

--- a/tests/dahua-face.spec.ts
+++ b/tests/dahua-face.spec.ts
@@ -66,7 +66,7 @@ describe('devices/dahua-face upsertFace', () => {
       String((addCall[1].body as Buffer).length),
     );
     expect(addCall[1].headers.connection).toBe('close');
-    expect(addCall[1].headers.expect).toBe('');
+    expect(addCall[1].headers.expect).toBeUndefined();
     expect(addCall[1].headers.authorization).toContain(
       'uri="/cgi-bin/FaceInfoManager.cgi?action=add"',
     );


### PR DESCRIPTION
## Summary
- drop the unused `Expect` header from both digest POST requests so undici no longer rejects them
- adjust the Dahua face unit test to assert the header is now absent

## Testing
- npm run build
- npm test -- --run *(fails: `syncToDevice > batches and sends face requests with a concurrency limit` is failing on the base branch as well)*

------
https://chatgpt.com/codex/tasks/task_e_68d121b9e43c8333bb031a1fb8ce79e0