### PR TITLE
Improve Dahua face push diagnostics and validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "bullmq": "^5.6.3",
         "dotenv": "^16.4.5",
         "fastify": "^4.28.1",
+        "form-data": "^4.0.0",
         "ioredis": "^5.3.2",
         "p-limit": "^7.1.1",
         "pino": "^8.17.0",
@@ -1995,7 +1996,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/atomic-sleep": {
@@ -2108,7 +2108,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2243,7 +2242,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2357,7 +2355,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2431,7 +2428,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2446,7 +2442,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2456,7 +2451,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2473,7 +2467,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2486,7 +2479,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3077,7 +3069,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3141,7 +3132,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3151,7 +3141,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3176,7 +3165,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3254,7 +3242,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3284,7 +3271,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3297,7 +3283,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3313,7 +3298,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3634,7 +3618,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3667,7 +3650,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3677,7 +3659,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@prisma/client": "^5.22.0",
     "bullmq": "^5.6.3",
     "dotenv": "^16.4.5",
+    "form-data": "^4.0.0",
     "fastify": "^4.28.1",
     "ioredis": "^5.3.2",
     "p-limit": "^7.1.1",

--- a/src/devices/dahua-face.ts
+++ b/src/devices/dahua-face.ts
@@ -1,4 +1,31 @@
+import { logger } from "../core/logger.js";
 import { digestPostJson } from "../utils/digest.js";
+import { normalizeBase64Jpeg } from "../utils/image.js";
+
+function previewBody(body: string) {
+  return body.length > 2000 ? `${body.slice(0, 2000)}…[truncated]` : body;
+}
+
+function logFailure(
+  action: string,
+  res: { status: number; text: string; headers: Record<string, string> },
+) {
+  let parsed: unknown = res.text;
+  try {
+    parsed = JSON.parse(res.text);
+  } catch {}
+
+  logger.warn(
+    {
+      action,
+      status: res.status,
+      headers: res.headers,
+      body: previewBody(res.text),
+      parsed,
+    },
+    "dahua-face request failed",
+  );
+}
 
 export interface DahuaFaceDevice {
   host: string;
@@ -19,8 +46,10 @@ export async function upsertFace(
 ): Promise<"added" | "updated"> {
   const scheme = device.scheme ?? "http";
   const baseUrl = `${scheme}://${device.host}/cgi-bin/FaceInfoManager.cgi`;
-  const info: Record<string, unknown> = { PhotoData: [photoBase64] };
-  if (userName) info.UserName = userName;
+  const { b64 } = normalizeBase64Jpeg(photoBase64);
+  const safeName = userName?.trim();
+  const info: Record<string, unknown> = { PhotoData: [b64] };
+  if (safeName) info.UserName = safeName.slice(0, 32);
   const body = { UserID: userId, Info: info };
 
   const add = await digestPostJson(
@@ -30,6 +59,7 @@ export async function upsertFace(
     device.pass,
   );
   if (add.status === 200 && /OK/i.test(add.text)) return "added";
+  logFailure("add", add);
 
   const upd = await digestPostJson(
     `${baseUrl}?action=update`,
@@ -38,8 +68,11 @@ export async function upsertFace(
     device.pass,
   );
   if (upd.status === 200 && /OK/i.test(upd.text)) return "updated";
+  logFailure("update", upd);
 
   throw new Error(
-    `face upsert failed: add=${add.status} ${add.text} | update=${upd.status} ${upd.text}`,
+    `face upsert failed: add=${add.status} ${previewBody(add.text)} | update=${upd.status} ${previewBody(
+      upd.text,
+    )}`,
   );
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,76 @@
+import FormData from 'form-data';
+
+export const ACCEPT_HEADER = 'application/json, text/plain, */*';
+
+type FetchError = Error & {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+};
+
+type FetchResponse = Awaited<ReturnType<typeof fetch>>;
+
+type FetchVerboseResult<T = unknown> = {
+  res: FetchResponse;
+  data: T;
+  headers: Record<string, string>;
+  raw: string;
+};
+
+function normalizeHeaders(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of headers.entries()) {
+    out[key] = value;
+  }
+  return out;
+}
+
+function truncateBody(body: string): string {
+  if (body.length <= 2000) return body;
+  return `${body.slice(0, 2000)}…[truncated]`;
+}
+
+export async function fetchVerbose(url: string, init: RequestInit = {}): Promise<FetchVerboseResult> {
+  const res = await fetch(url, init);
+  const raw = await res.text();
+  const headers = normalizeHeaders(res.headers);
+  const preview = truncateBody(raw);
+
+  if (!res.ok) {
+    const err: FetchError = Object.assign(
+      new Error(`HTTP ${res.status} ${res.statusText}`),
+      {
+        status: res.status,
+        headers,
+        body: preview,
+      },
+    );
+    throw err;
+  }
+
+  try {
+    return { res, data: JSON.parse(raw), headers, raw };
+  } catch {
+    return { res, data: raw, headers, raw };
+  }
+}
+
+export async function postJson(url: string, payload: unknown, headers: Record<string, string> = {}) {
+  return fetchVerbose(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function postMultipart(
+  url: string,
+  fields: Record<string, string>,
+  headers: Record<string, string> = {},
+) {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    fd.append(key, value);
+  }
+  return fetchVerbose(url, { method: 'POST', body: fd as any, headers });
+}

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,73 @@
+export function normalizeBase64Jpeg(b64: string) {
+  if (typeof b64 !== 'string') {
+    throw new Error('face_image_b64 must be a string');
+  }
+
+  let cleaned = b64.replace(/^data:.*?;base64,/, '').trim();
+  cleaned = cleaned.replace(/\s+/g, '');
+
+  const pad = cleaned.length % 4;
+  if (pad) {
+    cleaned += '='.repeat(4 - pad);
+  }
+
+  if (!/^[A-Za-z0-9+/=]+$/.test(cleaned)) {
+    throw new Error('face_image_b64 contains invalid base64 characters');
+  }
+
+  const padChars = cleaned.endsWith('==') ? 2 : cleaned.endsWith('=') ? 1 : 0;
+  const bytes = Math.floor((cleaned.length * 3) / 4) - padChars;
+  if (bytes > 350_000) {
+    throw new Error(`face_image_b64 too large: ${bytes} bytes`);
+  }
+
+  return { b64: cleaned, bytes };
+}
+
+export function buildFacePayload(u: {
+  personId: string;
+  name?: string;
+  imageB64: string;
+}) {
+  const { issues, normalized, name } = validateFaceRequest(u);
+  if (issues.length || !normalized) {
+    throw new Error(issues.join('; ') || 'invalid face payload');
+  }
+
+  return {
+    personId: u.personId,
+    name,
+    image: normalized.b64,
+  };
+}
+
+export function validateFaceRequest(u: {
+  personId: string;
+  name?: string;
+  imageB64: string;
+}) {
+  const issues: string[] = [];
+  if (!/^[\w\-:.@]{1,64}$/.test(u.personId)) {
+    issues.push('personId invalid (expect ASCII word chars, <=64)');
+  }
+
+  let normalized: ReturnType<typeof normalizeBase64Jpeg> | undefined;
+  try {
+    normalized = normalizeBase64Jpeg(u.imageB64);
+  } catch (err) {
+    issues.push((err as Error).message);
+  }
+
+  const name = u.name?.trim();
+  let safeName: string | undefined;
+  if (!name) {
+    issues.push('name required');
+  } else if (name.length > 32) {
+    issues.push('name too long (>32)');
+    safeName = name.slice(0, 32);
+  } else {
+    safeName = name;
+  }
+
+  return { issues, normalized, name: safeName };
+}

--- a/tests/dahua-face.spec.ts
+++ b/tests/dahua-face.spec.ts
@@ -54,6 +54,7 @@ describe('devices/dahua-face upsertFace', () => {
     expect(request).toHaveBeenCalledTimes(2);
     const challengeCall = request.mock.calls[0];
     expect(challengeCall[1].headers['content-length']).toBe('0');
+    expect(challengeCall[1].headers.accept).toBe('application/json, text/plain, */*');
     const addCall = request.mock.calls[1];
     expect(addCall[0]).toBe('http://1.2.3.4/cgi-bin/FaceInfoManager.cgi?action=add');
     expect(Buffer.isBuffer(addCall[1].body)).toBe(true);
@@ -66,7 +67,8 @@ describe('devices/dahua-face upsertFace', () => {
       String((addCall[1].body as Buffer).length),
     );
     expect(addCall[1].headers.connection).toBe('close');
-    expect(addCall[1].headers.expect).toBe('');
+    expect(addCall[1].headers.expect).toBeUndefined();
+    expect(addCall[1].headers.accept).toBe('application/json, text/plain, */*');
     expect(addCall[1].headers.authorization).toContain(
       'uri="/cgi-bin/FaceInfoManager.cgi?action=add"',
     );


### PR DESCRIPTION
## Summary
- add reusable helpers for verbose fetch logging, JPEG base64 normalization, and strict face payload validation
- extend digest POST handling and the Dahua face device integration to normalize payloads, include Accept headers, and log detailed failure context
- tighten sync-service face uploads to sanitize inputs, require names, and reuse the new validation while updating tests accordingly
- declare the form-data dependency used by the new multipart helper

## Testing
- npm run build
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d121b9e43c8333bb031a1fb8ce79e0